### PR TITLE
Fix AudioBuffer import path to resolve typing.Union instantiation error

### DIFF
--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt.py
@@ -32,7 +32,8 @@ from livekit.agents import (
     stt,
     utils,
 )
-from livekit.agents.utils import AudioBuffer, merge_frames
+from livekit.agents.utils.audio import AudioBuffer
+from livekit.agents.utils import merge_frames
 
 from .log import logger
 from .models import SarvamLanguages, SarvamSTTModels


### PR DESCRIPTION
### Summary of changes
Fixed an import statement for `AudioBuffer` class to resolve a `TypeError: Cannot instantiate typing.Union` error that was occurring during speech stream initialization.

### Motivation/Context
The error was preventing proper initialization of the speech stream in the Sarvam STT implementation due to an incorrect import path for the `AudioBuffer` class. This was causing the speech-to-text functionality to fail.

### Implementation details
- Modified the import statement in `stt.py` to use the correct path:
  ```python
  from livekit.agents.utils.audio import AudioBuffer
  ```
- Removed the generic import from `livekit.agents.utils`
- No changes to the actual functionality, just fixing the import path

### Potential impacts and considerations
- This is a low-risk change that only fixes an import statement
- No behavioral changes to the codebase
- All existing functionality should remain the same
- Tests should be run to verify the speech stream initialization works correctly

The error logs showed this was causing failures in production, so this fix should resolve those issues and allow the speech-to-text functionality to work as intended.