### PR TITLE
Fix AudioBuffer instantiation error in Sarvam STT plugin

### DIFF
--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt.py
@@ -32,7 +32,7 @@ from livekit.agents import (
     stt,
     utils,
 )
-from livekit.agents.utils.audio import AudioBuffer
+from livekit.agents.utils.audio import AudioBuffer, create_audio_buffer
 from livekit.agents.utils import merge_frames
 
 from .log import logger
@@ -203,7 +203,7 @@ class SpeechStream(stt.SpeechStream):
         self._api_key = api_key
         self._session = http_session
         self._audio_energy_filter = _AudioEnergyFilter()
-        self._buffer = AudioBuffer(
+        self._buffer = create_audio_buffer(
             sample_rate=opts.sample_rate,
             num_channels=opts.num_channels,
         )


### PR DESCRIPTION
### Summary of changes
Fixed a TypeError that occurred when instantiating AudioBuffer in the Sarvam STT plugin. The error was caused by attempting to directly instantiate a typing.Union type. The fix replaces direct AudioBuffer instantiation with the proper factory function `create_audio_buffer`.

### Motivation/Context
The error was preventing proper initialization of the speech recognition stream:
```python
TypeError: Cannot instantiate typing.Union
```
This was blocking the STT functionality in the Sarvam plugin.

### Implementation details
- Modified `SpeechStream.__init__` to use `create_audio_buffer` factory function
- Added proper import for `create_audio_buffer` from `livekit.agents.utils.audio`
- Maintains existing audio buffer configuration parameters

Before:
```python
self._buffer = AudioBuffer(
    sample_rate=opts.sample_rate,
    num_channels=opts.num_channels,
)
```

After:
```python
self._buffer = create_audio_buffer(
    sample_rate=opts.sample_rate,
    num_channels=opts.num_channels,
)
```

### Potential impacts and considerations
- No breaking changes to the public API
- No changes to functionality - this is purely a fix for proper type instantiation
- Maintains compatibility with existing LiveKit audio processing pipeline
- No performance impact expected

The change aligns with LiveKit's audio buffer creation patterns and resolves the typing error while maintaining all existing functionality.